### PR TITLE
Storybook のビルドの設定を修正

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,7 +9,7 @@ module.exports = {
           loader: require.resolve("ts-loader"),
           options: {
             compilerOptions: {
-              noEmit: true,
+              declaration: false,
             },
           },
         },


### PR DESCRIPTION
Storybook 起動時に以下のエラーが出ていたので、Storybook のビルドの設定を修正した。

```
Module build failed (from ./node_modules/ts-loader/index.js):
Error: TypeScript emitted no output for /my-react-component/src/components/Button/Button.stories.tsx.
    at makeSourceMapAndFinish (/my-react-component/node_modules/ts-loader/dist/index.js:88:18)
    at successLoader (/my-react-component/node_modules/ts-loader/dist/index.js:74:9)
    at Object.loader (/my-react-component/node_modules/ts-loader/dist/index.js:25:5)
```

型定義ファイルだけを出力しないようにした。